### PR TITLE
Update pandoc odt argument

### DIFF
--- a/resumemacs.sh
+++ b/resumemacs.sh
@@ -195,7 +195,7 @@ function make_odt {
         --from=latex \
         --to=odt \
         --template="$ODT_BASE_TEMPLATE" \
-        --reference-odt="$ODT_REFERENCE" \
+        --reference-doc="$ODT_REFERENCE" \
         --include-before-body="$header_file" \
         --output="$target_file" \
         "$src_file"


### PR DESCRIPTION
--reference-odt has been removed, this is what should be used --reference-doc from now on

Thanks for the help in  easing the pain of the resume making/maintenance.